### PR TITLE
fix date timezone

### DIFF
--- a/js/watchfaceEditor.js
+++ b/js/watchfaceEditor.js
@@ -2382,9 +2382,9 @@ var wfe = {
         date_change: function () {
             var t = $("in-date").valueAsDate;
             try {
-                wfe.data.day = t.getDate();
-                wfe.data.month = t.getMonth() + 1;
-                wfe.data.weekDay = t.getDay() > 0 ? t.getDay() - 1 : 6;
+                wfe.data.day = t.getUTCDate();
+                wfe.data.month = t.getUTCMonth() + 1;
+                wfe.data.weekDay = t.getUTCDay() > 0 ? t.getUTCDay() - 1 : 6;
                 removeByClass("c_date_sepday");
                 removeByClass("c_date_weekday");
                 removeByClass("c_date_sepmonth");


### PR DESCRIPTION
input type="date" is [timezone-less](https://austinfrance.wordpress.com/2012/07/09/html5-date-input-field-and-valueasdate-timezone-gotcha-3/) so converting to date will infer local timezone.

Removing timezone from the date functions fixes timezone issues.