### PR TITLE
Fixed incorrectly displayed battery bar

### DIFF
--- a/js/watchfaceEditor.js
+++ b/js/watchfaceEditor.js
@@ -3576,7 +3576,7 @@ var wfe = {
                 wfe.view.setTextPos(wfe.coords.batterytext, wfe.data.battery, "c_battery_text");
             },
             scale: function () {
-                var end = Math.round(wfe.data.battery / (100 / (wfe.coords.batteryscale.Segments.length - 1)));
+                var end = Math.ceil(wfe.data.battery / (100 / (wfe.coords.batteryscale.Segments.length - 1)));
                 for (var i = 0; i <= end; i++) {
                     t = $c(wfe.coords.batteryscale.StartImageIndex + i);
                     wfe.view.setPos(t, wfe.coords.batteryscale.Segments[i]);


### PR DESCRIPTION
For example, if the amount of segments is 11, then the image10 shall be shown for 100..91%, image9 for 90..81%, etc. This is how the watch actually behaves with the 1.1.2.05 firmware.